### PR TITLE
Simplified type names for Java basic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Rule rule = RuleDsl.ruleBuilder()
 or using XML:
 ```xml
 <Rule xmlns="http://www.sabre.com/schema/oss/yare/rules/v1">
-    <Attribute name="ruleName" value="Should match flight with first class of service" type="java.lang.String"/>
+    <Attribute name="ruleName" value="Should match flight with first class of service" type="String"/>
     <Fact name="flightFact" type="com.sabre.oss.yare.example.Flight"/>
     <Predicate>
         <Operator type="equal">

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
@@ -152,7 +152,7 @@ public class TypeTypeConverter implements TypeConverter {
     private Optional<String> tryToResolveInnerClassName(String typeName) {
         int lastDot = typeName.lastIndexOf('.');
         if (lastDot != -1) {
-            String innerClassName =  typeName.substring(0, lastDot) + '$' + typeName.substring(lastDot + 1);
+            String innerClassName = typeName.substring(0, lastDot) + '$' + typeName.substring(lastDot + 1);
             return Optional.of(innerClassName);
         }
         return Optional.empty();
@@ -170,7 +170,8 @@ public class TypeTypeConverter implements TypeConverter {
 
     private String convertType(Class<?> type) {
         return typeAliasResolver.hasAliasFor(type) ?
-                typeAliasResolver.getAliasFor(type).getAlias() : type.getCanonicalName();
+                typeAliasResolver.getAliasFor(type).getAlias() :
+                type.getCanonicalName();
     }
 
     private String convertType(ParameterizedType type) {

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
@@ -129,24 +129,9 @@ public class TypeTypeConverter implements TypeConverter {
 
     private Type loadAsInnerClass(String typeName) {
         return tryToResolveInnerClassName(typeName)
-                .map(this::loadClass)
+                .flatMap(this::tryToLoadClass)
                 .orElseThrow(() -> new IllegalArgumentException(
                         String.format("Can't convert '%s' into Java type", typeName)));
-    }
-
-    private Type loadClass(String typeName) {
-        return tryToLoadClass(typeName)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        String.format("Can't convert '%s' into Java type", typeName)));
-    }
-
-    private Optional<Type> tryToLoadClass(String typeName) {
-        try {
-            Type type = Thread.currentThread().getContextClassLoader().loadClass(typeName);
-            return Optional.of(type);
-        } catch (ClassNotFoundException ex) {
-            return Optional.empty();
-        }
     }
 
     private Optional<String> tryToResolveInnerClassName(String typeName) {
@@ -156,6 +141,15 @@ public class TypeTypeConverter implements TypeConverter {
             return Optional.of(innerClassName);
         }
         return Optional.empty();
+    }
+
+    private Optional<Type> tryToLoadClass(String typeName) {
+        try {
+            Type type = Thread.currentThread().getContextClassLoader().loadClass(typeName);
+            return Optional.of(type);
+        } catch (ClassNotFoundException ex) {
+            return Optional.empty();
+        }
     }
 
     private String convertType(Object value) {

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
@@ -182,5 +182,4 @@ public class TypeTypeConverter implements TypeConverter {
         }
         return stringJoiner.toString();
     }
-
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/TypeTypeConverter.java
@@ -53,7 +53,8 @@ import static com.sabre.oss.yare.common.converter.StringTypeConverter.NULL_LITER
  * </pre>
  */
 public class TypeTypeConverter implements TypeConverter {
-    private static final Pattern typePattern = Pattern.compile("([a-zA-Z][a-zA-Z0-9_$\\.]*)(?:<((?:,{0,1}[a-zA-Z][a-zA-Z0-9_$\\.]*)*)>){0,1}");
+    private static final Pattern typePattern =
+            Pattern.compile("([a-zA-Z][a-zA-Z0-9_$\\.]*)(?:<((?:,{0,1}[a-zA-Z][a-zA-Z0-9_$\\.]*)*)>){0,1}");
 
     private final Map<String, Type> stringToTypeCache = new ConcurrentHashMap<>();
     private final Map<Type, String> typeToStringCache = new ConcurrentHashMap<>();
@@ -91,58 +92,94 @@ public class TypeTypeConverter implements TypeConverter {
     }
 
     private Type convertString(String value) {
-        if (typeAliasResolver.hasAliasFor(value)) {
-            return typeAliasResolver.getAliasFor(value).getType();
-        }
+        return typeAliasResolver.hasAliasFor(value) ?
+                typeAliasResolver.getAliasFor(value).getType() :
+                convertRawTypeString(value);
+    }
+
+    private Type convertRawTypeString(String value) {
         Matcher matcher = typePattern.matcher(value);
         if (matcher.matches()) {
             String rawTypeName = matcher.group(1);
             String parameters = matcher.group(2);
-
-            if (parameters == null || parameters.isEmpty()) {
-                try {
-                    return Thread.currentThread().getContextClassLoader().loadClass(rawTypeName);
-                } catch (ClassNotFoundException e) {
-                    int lastDot = rawTypeName.lastIndexOf('.');
-                    if (lastDot != -1) {
-                        String innerClassName = rawTypeName.substring(0, lastDot) + '$' + rawTypeName.substring(lastDot + 1);
-                        try {
-                            return Thread.currentThread().getContextClassLoader().loadClass(innerClassName);
-                        } catch (ClassNotFoundException ex) {
-                            throw new IllegalArgumentException(String.format("Can't convert '%s' into Java type", innerClassName));
-                        }
-                    }
-                    throw new IllegalArgumentException(String.format("Can't convert '%s' into Java type", rawTypeName));
-                }
-            } else {
-                Type rawType = fromString(Type.class, rawTypeName);
-                List<Type> parameterTypes = new ArrayList<>();
-                for (String paramTypeName : parameters.split(",")) {
-                    parameterTypes.add(fromString(Type.class, paramTypeName));
-                }
-                return new InternalParameterizedType(null, (Class<?>) rawType, parameterTypes.toArray(new Type[0]));
-            }
+            return isParametrizedType(parameters) ?
+                    convertParametrizedTypeStrings(rawTypeName, parameters) :
+                    convertSimpleTypeString(rawTypeName);
         }
         throw new IllegalArgumentException(String.format("Can't convert '%s' into Java type", value));
     }
 
+    private Boolean isParametrizedType(String parameters) {
+        return parameters != null && !parameters.isEmpty();
+    }
+
+    private Type convertParametrizedTypeStrings(String rawTypeName, String parameters) {
+        List<Type> parameterTypes = new ArrayList<>();
+        for (String paramTypeName : parameters.split(",")) {
+            parameterTypes.add(fromString(Type.class, paramTypeName));
+        }
+        Class<?> rawType = (Class<?>) fromString(Type.class, rawTypeName);
+        return new InternalParameterizedType(null, rawType, parameterTypes.toArray(new Type[0]));
+    }
+
+    private Type convertSimpleTypeString(String typeName) {
+        return tryToLoadClass(typeName)
+                .orElseGet(() -> loadAsInnerClass(typeName));
+    }
+
+    private Type loadAsInnerClass(String typeName) {
+        return tryToResolveInnerClassName(typeName)
+                .map(this::loadClass)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Can't convert '%s' into Java type", typeName)));
+    }
+
+    private Type loadClass(String typeName) {
+        return tryToLoadClass(typeName)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Can't convert '%s' into Java type", typeName)));
+    }
+
+    private Optional<Type> tryToLoadClass(String typeName) {
+        try {
+            Type type = Thread.currentThread().getContextClassLoader().loadClass(typeName);
+            return Optional.of(type);
+        } catch (ClassNotFoundException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> tryToResolveInnerClassName(String typeName) {
+        int lastDot = typeName.lastIndexOf('.');
+        if (lastDot != -1) {
+            String innerClassName =  typeName.substring(0, lastDot) + '$' + typeName.substring(lastDot + 1);
+            return Optional.of(innerClassName);
+        }
+        return Optional.empty();
+    }
+
     private String convertType(Object value) {
         if (value instanceof Class) {
-            Class<?> type = (Class<?>) value;
-            return typeAliasResolver.hasAliasFor(type) ?
-                    typeAliasResolver.getAliasFor(type).getAlias() :
-                    type.getCanonicalName();
+            return convertType((Class<?>) value);
         }
         if (value instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) value;
-            String prefix = toString(null, parameterizedType.getRawType()) + '<';
-            StringJoiner stringJoiner = new StringJoiner(",", prefix, ">");
-            for (Type paramType : parameterizedType.getActualTypeArguments()) {
-                stringJoiner.add(toString(null, paramType));
-            }
-            return stringJoiner.toString();
+            return convertType((ParameterizedType) value);
         }
         throw new IllegalArgumentException("Unsupported type");
+    }
+
+    private String convertType(Class<?> type) {
+        return typeAliasResolver.hasAliasFor(type) ?
+                typeAliasResolver.getAliasFor(type).getAlias() : type.getCanonicalName();
+    }
+
+    private String convertType(ParameterizedType type) {
+        String prefix = toString(null, type.getRawType()) + '<';
+        StringJoiner stringJoiner = new StringJoiner(",", prefix, ">");
+        for (Type paramType : type.getActualTypeArguments()) {
+            stringJoiner.add(toString(null, paramType));
+        }
+        return stringJoiner.toString();
     }
 
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.sabre.oss.yare.common.converter.aliases;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+final class ClassUtils {
+    private static final Map<String, Class<?>> primitiveTypes =
+            new HashMap<String, Class<?>>() {
+                {
+                    put("int", Integer.TYPE);
+                    put("long", Long.TYPE);
+                    put("double", Double.TYPE);
+                    put("float", Float.TYPE);
+                    put("boolean", Boolean.TYPE);
+                    put("char", Character.TYPE);
+                    put("byte", Byte.TYPE);
+                    put("void", Void.TYPE);
+                    put("short", Short.TYPE);
+                }
+            };
+
+    private ClassUtils() { }
+
+    static Class<?> forName(String name) {
+        return Stream.of(
+                tryResolveTypeFor(name),
+                tryResolvePrimitiveTypeFor(name))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Could not resolve type for name: %s", name)));
+
+    }
+
+    private static Optional<Class<?>> tryResolveTypeFor(String name) {
+        try {
+            return Optional.of(Class.forName(name));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Class<?>> tryResolvePrimitiveTypeFor(String name) {
+        return primitiveTypes.containsKey(name) ?
+                Optional.of(primitiveTypes.get(name)) : Optional.empty();
+    }
+}

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
@@ -68,7 +68,6 @@ final class ClassUtils {
     }
 
     private static Optional<Class<?>> tryResolvePrimitiveTypeFor(String name) {
-        return primitiveTypes.containsKey(name) ?
-                Optional.of(primitiveTypes.get(name)) : Optional.empty();
+        return Optional.ofNullable(primitiveTypes.get(name));
     }
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -25,45 +25,18 @@
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-public enum TypeAlias {
-    OBJECT("Object", Object.class),
-    STRING("String", String.class),
-    INTEGER("Integer", Integer.class),
-    LONG("Long", Long.class),
-    DOUBLE("Double", Double.class),
-    BOOLEAN("Boolean", Boolean.class),
-    BYTE("Byte", Byte.class),
-    SHORT("Short", Short.class),
-    CHARACTER("Character", Character.class),
-    FLOAT("Float", Float.class),
-
-    P_INT("int", int.class),
-    P_LONG("long", long.class),
-    P_DOUBLE("double", double.class),
-    P_BOOLEAN("boolean", boolean.class),
-    P_BYTE("byte", byte.class),
-    P_SHORT("short", short.class),
-    P_CHAR("char", char.class),
-    P_FLOAT("float", float.class),
-
-    ZONED_DATE_TIME("ZonedDateTime", ZonedDateTime.class),
-
-    LIST("List", List.class),
-    MAP("Map", Map.class),
-    SET("Set", Set.class);
-
+public class TypeAlias {
     private final String name;
-
     private final Type type;
 
-    TypeAlias(String name, Type type) {
+    private TypeAlias(String name, Type type) {
         this.name = name;
         this.type = type;
+    }
+
+    public static TypeAlias of(String name, Type type) {
+        return new TypeAlias(name, type);
     }
 
     public String getAlias() {
@@ -73,5 +46,4 @@ public enum TypeAlias {
     public Type getType() {
         return type;
     }
-
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -26,7 +26,7 @@ package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
 
-public class TypeAlias {
+public final class TypeAlias {
     private final String name;
     private final Type type;
 

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -1,0 +1,27 @@
+package com.sabre.oss.yare.common.converter.aliases;
+
+import java.lang.reflect.Type;
+
+public enum TypeAlias {
+    STRING("String", String.class),
+    INTEGER("Integer", Integer.class);
+    //TODO!!!
+
+    private final String name;
+
+    private final Type type;
+
+    TypeAlias(String name, Type type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+}

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -1,12 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public enum TypeAlias {
+    OBJECT("Object", Object.class),
     STRING("String", String.class),
     INTEGER("Integer", Integer.class),
-    INT("int", int.class);
-    //TODO!!!
+    INT("int", int.class),
+    //TODO!!! add missing!
+
+    LIST("List", List.class),
+    MAP("Map", Map.class),
+    SET("Set", Set.class);
 
     private final String name;
 
@@ -17,7 +49,7 @@ public enum TypeAlias {
         this.type = type;
     }
 
-    public String getName() {
+    public String getAlias() {
         return name;
     }
 

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -4,7 +4,8 @@ import java.lang.reflect.Type;
 
 public enum TypeAlias {
     STRING("String", String.class),
-    INTEGER("Integer", Integer.class);
+    INTEGER("Integer", Integer.class),
+    INT("int", int.class);
     //TODO!!!
 
     private final String name;

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAlias.java
@@ -25,6 +25,7 @@
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,8 +34,24 @@ public enum TypeAlias {
     OBJECT("Object", Object.class),
     STRING("String", String.class),
     INTEGER("Integer", Integer.class),
-    INT("int", int.class),
-    //TODO!!! add missing!
+    LONG("Long", Long.class),
+    DOUBLE("Double", Double.class),
+    BOOLEAN("Boolean", Boolean.class),
+    BYTE("Byte", Byte.class),
+    SHORT("Short", Short.class),
+    CHARACTER("Character", Character.class),
+    FLOAT("Float", Float.class),
+
+    P_INT("int", int.class),
+    P_LONG("long", long.class),
+    P_DOUBLE("double", double.class),
+    P_BOOLEAN("boolean", boolean.class),
+    P_BYTE("byte", byte.class),
+    P_SHORT("short", short.class),
+    P_CHAR("char", char.class),
+    P_FLOAT("float", float.class),
+
+    ZONED_DATE_TIME("ZonedDateTime", ZonedDateTime.class),
 
     LIST("List", List.class),
     MAP("Map", Map.class),

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
@@ -25,50 +25,31 @@
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 public class TypeAliasResolver {
-
     public boolean hasAliasFor(Type type) {
-        return resolveAliasFor(type)
-                .isPresent();
+        return TypeAliases.mapAliasesByType().containsKey(type);
     }
 
     public boolean hasAliasFor(String name) {
-        return resolveAliasFor(name)
-                .isPresent();
+        return TypeAliases.mapAliasesByName().containsKey(name);
     }
 
     public TypeAlias getAliasFor(Type type) {
-        return resolveAliasFor(type)
-                .orElseThrow(() -> {
-                    String message = String.format("Could not find type alias for given type: %s", type);
-                    return new IllegalArgumentException(message);
-                });
+        TypeAlias alias = TypeAliases.mapAliasesByType().get(type);
+        if (alias == null) {
+            String message = String.format("Could not find type alias for given type: %s", type);
+            throw new IllegalArgumentException(message);
+        }
+        return alias;
     }
 
     public TypeAlias getAliasFor(String name) {
-        return resolveAliasFor(name)
-                .orElseThrow(() -> {
-                    String message = String.format("Could not find type alias for given name: %s", name);
-                    return new IllegalArgumentException(message);
-                });
+        TypeAlias alias = TypeAliases.mapAliasesByName().get(name);
+        if (alias == null) {
+            String message = String.format("Could not find type alias for given name: %s", name);
+            throw new IllegalArgumentException(message);
+        }
+        return alias;
     }
-
-    private Optional<TypeAlias> resolveAliasFor(Type type) {
-        return resolveAliasThat(a -> a.getType().equals(type));
-    }
-
-    private Optional<TypeAlias> resolveAliasFor(String name) {
-        return resolveAliasThat(a -> a.getAlias().equals(name));
-    }
-
-    private Optional<TypeAlias> resolveAliasThat(Predicate<TypeAlias> predicate) {
-        return Stream.of(TypeAlias.values())
-                .filter(predicate)
-                .findAny();
-    }
-
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
@@ -27,16 +27,22 @@ package com.sabre.oss.yare.common.converter.aliases;
 import java.lang.reflect.Type;
 
 public class TypeAliasResolver {
+    private TypeAliases typeAliases;
+
+    public TypeAliasResolver() {
+        this.typeAliases = new TypeAliases();
+    }
+
     public boolean hasAliasFor(Type type) {
-        return TypeAliases.mapAliasesByType().containsKey(type);
+        return typeAliases.getAliasesMappedByType().containsKey(type);
     }
 
     public boolean hasAliasFor(String name) {
-        return TypeAliases.mapAliasesByName().containsKey(name);
+        return typeAliases.getAliasesMappedByName().containsKey(name);
     }
 
     public TypeAlias getAliasFor(Type type) {
-        TypeAlias alias = TypeAliases.mapAliasesByType().get(type);
+        TypeAlias alias = typeAliases.getAliasesMappedByType().get(type);
         if (alias == null) {
             String message = String.format("Could not find type alias for given type: %s", type);
             throw new IllegalArgumentException(message);
@@ -45,7 +51,7 @@ public class TypeAliasResolver {
     }
 
     public TypeAlias getAliasFor(String name) {
-        TypeAlias alias = TypeAliases.mapAliasesByName().get(name);
+        TypeAlias alias = typeAliases.getAliasesMappedByName().get(name);
         if (alias == null) {
             String message = String.format("Could not find type alias for given name: %s", name);
             throw new IllegalArgumentException(message);

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;
@@ -38,7 +62,7 @@ public class TypeAliasResolver {
     }
 
     private Optional<TypeAlias> resolveAliasFor(String name) {
-        return resolveAliasThat(a -> a.getName().equals(name));
+        return resolveAliasThat(a -> a.getAlias().equals(name));
     }
 
     private Optional<TypeAlias> resolveAliasThat(Predicate<TypeAlias> predicate) {

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolver.java
@@ -1,0 +1,50 @@
+package com.sabre.oss.yare.common.converter.aliases;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class TypeAliasResolver {
+
+    public boolean hasAliasFor(Type type) {
+        return resolveAliasFor(type)
+                .isPresent();
+    }
+
+    public boolean hasAliasFor(String name) {
+        return resolveAliasFor(name)
+                .isPresent();
+    }
+
+    public TypeAlias getAliasFor(Type type) {
+        return resolveAliasFor(type)
+                .orElseThrow(() -> {
+                    String message = String.format("Could not find type alias for given type: %s", type);
+                    return new IllegalArgumentException(message);
+                });
+    }
+
+    public TypeAlias getAliasFor(String name) {
+        return resolveAliasFor(name)
+                .orElseThrow(() -> {
+                    String message = String.format("Could not find type alias for given name: %s", name);
+                    return new IllegalArgumentException(message);
+                });
+    }
+
+    private Optional<TypeAlias> resolveAliasFor(Type type) {
+        return resolveAliasThat(a -> a.getType().equals(type));
+    }
+
+    private Optional<TypeAlias> resolveAliasFor(String name) {
+        return resolveAliasThat(a -> a.getName().equals(name));
+    }
+
+    private Optional<TypeAlias> resolveAliasThat(Predicate<TypeAlias> predicate) {
+        return Stream.of(TypeAlias.values())
+                .filter(predicate)
+                .findAny();
+    }
+
+}

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
@@ -1,0 +1,58 @@
+package com.sabre.oss.yare.common.converter.aliases;
+
+import java.lang.reflect.Type;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class TypeAliases {
+    private final static Map<String, TypeAlias> nameToAliasMap;
+    private final static Map<Type, TypeAlias> typeToAliasMap;
+
+    static {
+        nameToAliasMap = new HashMap<>();
+        typeToAliasMap = new HashMap<>();
+
+        registerAlias("Object", Object.class);
+        registerAlias("String", String.class);
+        registerAlias("Integer", Integer.class);
+        registerAlias("Long", Long.class);
+        registerAlias("Double", Double.class);
+        registerAlias("Boolean", Boolean.class);
+        registerAlias("Byte", Byte.class);
+        registerAlias("Short", Short.class);
+        registerAlias("Character", Character.class);
+        registerAlias("Float", Float.class);
+
+        registerAlias("int", int.class);
+        registerAlias("long", long.class);
+        registerAlias("double", double.class);
+        registerAlias("boolean", boolean.class);
+        registerAlias("byte", byte.class);
+        registerAlias("short", short.class);
+        registerAlias("char", char.class);
+        registerAlias("float", float.class);
+
+        registerAlias("ZonedDateTime", ZonedDateTime.class);
+
+        registerAlias("List", List.class);
+        registerAlias("Map", Map.class);
+        registerAlias("Set", Set.class);
+    }
+
+    private static void registerAlias(String name, Type type) {
+        TypeAlias alias = TypeAlias.of(name, type);
+        nameToAliasMap.put(name, alias);
+        typeToAliasMap.put(type, alias);
+    }
+
+    static Map<String, TypeAlias> mapAliasesByName() {
+        return nameToAliasMap;
+    }
+
+    static Map<Type, TypeAlias> mapAliasesByType() {
+        return typeToAliasMap;
+    }
+}

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class TypeAliases {
-    private final static Map<String, TypeAlias> nameToAliasMap;
-    private final static Map<Type, TypeAlias> typeToAliasMap;
+final class TypeAliases {
+    private static final Map<String, TypeAlias> nameToAliasMap;
+    private static final Map<Type, TypeAlias> typeToAliasMap;
 
     static {
         nameToAliasMap = new HashMap<>();
@@ -70,6 +70,10 @@ class TypeAliases {
         TypeAlias alias = TypeAlias.of(name, type);
         nameToAliasMap.put(name, alias);
         typeToAliasMap.put(type, alias);
+    }
+
+    private TypeAliases() {
+
     }
 
     static Map<String, TypeAlias> mapAliasesByName() {

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/TypeAliases.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.sabre.oss.yare.common.converter.aliases;
 
 import java.lang.reflect.Type;

--- a/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
+++ b/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
@@ -32,6 +32,7 @@ Byte=java.lang.Byte
 Short=java.lang.Short
 Character=java.lang.Character
 Float=java.lang.Float
+Void=java.lang.Void
 
 int=int
 long=long

--- a/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
+++ b/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
@@ -1,0 +1,50 @@
+#
+# MIT License
+#
+# Copyright 2018 Sabre GLBL Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+Object=java.lang.Object
+String=java.lang.String
+Integer=java.lang.Integer
+Long=java.lang.Long
+Double=java.lang.Double
+Boolean=java.lang.Boolean
+Byte=java.lang.Byte
+Short=java.lang.Short
+Character=java.lang.Character
+Float=java.lang.Float
+
+int=int
+long=long
+double=double
+boolean=boolean
+byte=byte
+short=short
+char=char
+float=float
+void=void
+
+ZonedDateTime=java.time.ZonedDateTime
+
+List=java.util.List
+Map=java.util.Map
+Set=java.util.Set

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/DefaultTypeConvertersTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/DefaultTypeConvertersTest.java
@@ -89,7 +89,7 @@ class DefaultTypeConvertersTest {
                 Arguments.of(Integer.class, "123", 123),
                 Arguments.of(Long.class, "123", 123L),
                 Arguments.of(String.class, "test", "test"),
-                Arguments.of(Type.class, "java.lang.Object", Object.class),
+                Arguments.of(Type.class, "Object", Object.class),
                 Arguments.of(ZonedDateTime.class, "2014-12-02T10:45:30+02:00", ZonedDateTime.parse("2014-12-02T10:45:30+02:00"))
         );
     }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
@@ -107,6 +107,13 @@ class TypeTypeConverterTest {
         assertThat(converted).isEqualTo("@null");
     }
 
+    @Test
+    void shouldProperlyConvertAliasTypeFromFullyQualifiedString() {
+        Type converted = typeConverter.fromString(null, "java.lang.String");
+
+        assertThat(converted).isEqualTo(String.class);
+    }
+
     @ParameterizedTest
     @MethodSource("conversionParameters")
     void shouldProperlyConvertFromString(String toConvert, Type expected) {
@@ -125,13 +132,16 @@ class TypeTypeConverterTest {
 
     private static Stream<Arguments> conversionParameters() {
         return Stream.of(
-                Arguments.of("java.lang.Object", Object.class),
-                Arguments.of(NestedClass.class.getCanonicalName(), NestedClass.class),
-                Arguments.of("java.util.List<java.lang.String>", TypeUtils.parameterize(List.class, String.class)),
-                Arguments.of("java.util.Map<java.lang.String,java.lang.Object>", TypeUtils.parameterize(Map.class, String.class, Object.class))
+                Arguments.of("String", String.class),
+                Arguments.of("List<String>", TypeUtils.parameterize(List.class, String.class)),
+                Arguments.of("Object", Object.class),
+                Arguments.of("List<String>", TypeUtils.parameterize(List.class, String.class)),
+                Arguments.of("Map<String,Object>", TypeUtils.parameterize(Map.class, String.class, Object.class)),
+                Arguments.of(NestedClass.class.getCanonicalName(), NestedClass.class)
         );
     }
 
     private static class NestedClass {
     }
+
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
@@ -143,5 +143,4 @@ class TypeTypeConverterTest {
 
     private static class NestedClass {
     }
-
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/TypeTypeConverterTest.java
@@ -114,6 +114,14 @@ class TypeTypeConverterTest {
         assertThat(converted).isEqualTo(String.class);
     }
 
+    @Test
+    void shouldProperlyConvertNestedGenericToString() {
+        String converted = typeConverter.toString(null,
+                TypeUtils.parameterize(Map.class, String.class, TypeUtils.parameterize(List.class, Object.class)));
+
+        assertThat(converted).isEqualTo("Map<String,List<Object>>");
+    }
+
     @ParameterizedTest
     @MethodSource("conversionParameters")
     void shouldProperlyConvertFromString(String toConvert, Type expected) {

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/ClassUtilsTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/ClassUtilsTest.java
@@ -24,45 +24,48 @@
 
 package com.sabre.oss.yare.common.converter.aliases;
 
-import java.lang.reflect.Type;
-import java.util.Objects;
+import org.junit.jupiter.api.Test;
 
-public final class TypeAlias {
-    private final String name;
-    private final Type type;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    private TypeAlias(String name, Type type) {
-        this.name = name;
-        this.type = type;
+class ClassUtilsTest {
+    @Test
+    void shouldResolvePrimitiveTypeProperly() {
+        //given
+        String name = "int";
+
+        //when
+        Class<?> type = ClassUtils.forName(name);
+
+        //then
+        assertThat(type).isEqualTo(int.class);
     }
 
-    public static TypeAlias of(String name, Type type) {
-        return new TypeAlias(name, type);
+    @Test
+    void shouldResolveObjectTypeProperly() {
+        //given
+        String name = "java.lang.String";
+
+        //when
+        Class<?> type = ClassUtils.forName(name);
+
+        //then
+        assertThat(type).isEqualTo(String.class);
     }
 
-    public String getAlias() {
-        return name;
-    }
+    @Test
+    void shouldThrowExceptionForUnknownType() {
+        //given
+        String unknownTypeName = "UNKNOWN_TYPE_NAME";
 
-    public Type getType() {
-        return type;
-    }
+        //when
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> ClassUtils.forName(unknownTypeName));
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TypeAlias alias = (TypeAlias) o;
-        return Objects.equals(name, alias.name) &&
-                Objects.equals(type, alias.type);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, type);
+        //then
+        String expectedMessage = String.format("Could not resolve type for name: %s", unknownTypeName);
+        assertThat(e.getMessage()).isEqualTo(expectedMessage);
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/ClassUtilsTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/ClassUtilsTest.java
@@ -27,7 +27,7 @@ package com.sabre.oss.yare.common.converter.aliases;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ClassUtilsTest {
     @Test
@@ -59,13 +59,10 @@ class ClassUtilsTest {
         //given
         String unknownTypeName = "UNKNOWN_TYPE_NAME";
 
-        //when
-        IllegalArgumentException e = assertThrows(
-                IllegalArgumentException.class,
-                () -> ClassUtils.forName(unknownTypeName));
-
-        //then
+        //when /then
         String expectedMessage = String.format("Could not resolve type for name: %s", unknownTypeName);
-        assertThat(e.getMessage()).isEqualTo(expectedMessage);
+        assertThatThrownBy(() -> ClassUtils.forName(unknownTypeName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TypeAliasResolverTest {
-
     private TypeAliasResolver resolver = new TypeAliasResolver();
 
     @Test
@@ -114,5 +113,4 @@ class TypeAliasResolverTest {
         String expectedMessage = String.format("Could not find type alias for given type: %s", unknownType);
         assertThat(e.getMessage()).isEqualTo(expectedMessage);
     }
-
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -1,0 +1,64 @@
+package com.sabre.oss.yare.common.converter.aliases;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TypeAliasResolverTest {
+
+    private TypeAliasResolver resolver = new TypeAliasResolver();
+
+    @Test
+    void shouldResolveTypeAliasForGivenName() {
+        //given
+        String name = "String";
+
+        //when
+        TypeAlias alias = resolver.getAliasFor(name);
+
+        //then
+        assertThat(alias).isEqualTo(TypeAlias.STRING);
+    }
+
+    @Test
+    void shouldResolveTypeExistenceAliasForGivenName() {
+        //given
+        String name = "String";
+
+        //when
+        Boolean hasAlias = resolver.hasAliasFor(name);
+
+        //then
+        assertThat(hasAlias).isTrue();
+    }
+
+    @Test
+    void shouldResolveTypeAliasForGivenType() {
+    }
+
+    @Test
+    void shouldThrowExceptionForGivenName() {
+        //given
+        String name = "NOT_EXISTING_NAME";
+
+        //when
+        TypeAlias alias = resolver.getAliasFor(name);
+
+        //then
+        assertThat(alias).isEqualTo(TypeAlias.STRING);
+    }
+
+    @Test
+    void shouldThrowExceptionForGivenType() {
+        //given
+        Class<?> not_handled_class = TypeAlias.class;
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> {
+            //when
+            resolver.getAliasFor(not_handled_class);
+        }, "Could not find type alias for given type: xxx!"); //TODO!!!
+    }
+
+}

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -22,7 +22,7 @@ class TypeAliasResolverTest {
     }
 
     @Test
-    void shouldResolveTypeExistenceAliasForGivenName() {
+    void shouldResolveTypeAliasExistenceForGivenName() {
         //given
         String name = "String";
 
@@ -35,30 +35,58 @@ class TypeAliasResolverTest {
 
     @Test
     void shouldResolveTypeAliasForGivenType() {
-    }
-
-    @Test
-    void shouldThrowExceptionForGivenName() {
         //given
-        String name = "NOT_EXISTING_NAME";
+        Class<?> type = String.class;
 
         //when
-        TypeAlias alias = resolver.getAliasFor(name);
+        TypeAlias alias = resolver.getAliasFor(type);
 
         //then
         assertThat(alias).isEqualTo(TypeAlias.STRING);
     }
 
     @Test
-    void shouldThrowExceptionForGivenType() {
+    void shouldResolveTypeAliasExistenceForGivenType() {
         //given
-        Class<?> not_handled_class = TypeAlias.class;
+        Class<?> type = String.class;
+
+        //when
+        Boolean hasAlias = resolver.hasAliasFor(type);
 
         //then
-        assertThrows(IllegalArgumentException.class, () -> {
-            //when
-            resolver.getAliasFor(not_handled_class);
-        }, "Could not find type alias for given type: xxx!"); //TODO!!!
+        assertThat(hasAlias).isTrue();
+    }
+
+
+    @Test
+    void shouldThrowExceptionForUnknownName() {
+        //given
+        String unknownName = "UNKNOWN_NAME";
+
+        //when
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> resolver.getAliasFor(unknownName));
+
+
+        //then
+        String expectedMessage = String.format("Could not find type alias for given name: %s", unknownName);
+        assertThat(e.getMessage()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    void shouldThrowExceptionForUnknownType() {
+        //given
+        Class<?> unknownType = TypeAlias.class;
+
+        //when
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> resolver.getAliasFor(unknownType));
+
+        //then
+        String expectedMessage = String.format("Could not find type alias for given type: %s", unknownType);
+        assertThat(e.getMessage()).isEqualTo(expectedMessage);
     }
 
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -42,7 +42,8 @@ class TypeAliasResolverTest {
         TypeAlias alias = resolver.getAliasFor(name);
 
         //then
-        assertThat(alias).isEqualTo(TypeAlias.STRING);
+        assertThat(alias.getAlias()).isEqualTo("String");
+        assertThat(alias.getType()).isEqualTo(String.class);
     }
 
     @Test
@@ -66,7 +67,8 @@ class TypeAliasResolverTest {
         TypeAlias alias = resolver.getAliasFor(type);
 
         //then
-        assertThat(alias).isEqualTo(TypeAlias.STRING);
+        assertThat(alias.getAlias()).isEqualTo("String");
+        assertThat(alias.getType()).isEqualTo(String.class);
     }
 
     @Test

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.sabre.oss.yare.common.converter.aliases;
 
 import org.junit.jupiter.api.Test;

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasResolverTest.java
@@ -27,7 +27,7 @@ package com.sabre.oss.yare.common.converter.aliases;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TypeAliasResolverTest {
     private TypeAliasResolver resolver = new TypeAliasResolver();
@@ -88,15 +88,11 @@ class TypeAliasResolverTest {
         //given
         String unknownName = "UNKNOWN_NAME";
 
-        //when
-        IllegalArgumentException e = assertThrows(
-                IllegalArgumentException.class,
-                () -> resolver.getAliasFor(unknownName));
-
-
-        //then
+        //when /then
         String expectedMessage = String.format("Could not find type alias for given name: %s", unknownName);
-        assertThat(e.getMessage()).isEqualTo(expectedMessage);
+        assertThatThrownBy(() -> resolver.getAliasFor(unknownName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
     }
 
     @Test
@@ -104,13 +100,10 @@ class TypeAliasResolverTest {
         //given
         Class<?> unknownType = TypeAlias.class;
 
-        //when
-        IllegalArgumentException e = assertThrows(
-                IllegalArgumentException.class,
-                () -> resolver.getAliasFor(unknownType));
-
-        //then
+        //when /then
         String expectedMessage = String.format("Could not find type alias for given type: %s", unknownType);
-        assertThat(e.getMessage()).isEqualTo(expectedMessage);
+        assertThatThrownBy(() -> resolver.getAliasFor(unknownType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedMessage);
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
@@ -24,45 +24,30 @@
 
 package com.sabre.oss.yare.common.converter.aliases;
 
-import java.lang.reflect.Type;
-import java.util.Objects;
+import org.junit.jupiter.api.Test;
 
-public final class TypeAlias {
-    private final String name;
-    private final Type type;
+import java.time.ZonedDateTime;
+import java.util.List;
 
-    private TypeAlias(String name, Type type) {
-        this.name = name;
-        this.type = type;
-    }
+import static org.assertj.core.api.Assertions.assertThat;
 
-    public static TypeAlias of(String name, Type type) {
-        return new TypeAlias(name, type);
-    }
+class TypeAliasesTest {
+    @Test
+    void shouldInitializeTypeAliasesFromPropertiesFile() {
+        //when
+        TypeAliases typeAliases = new TypeAliases();
 
-    public String getAlias() {
-        return name;
-    }
+        //then
+        assertThat(typeAliases.getAliasesMappedByName()).isNotEmpty();
+        assertThat(typeAliases.getAliasesMappedByName())
+                .containsKeys("Object", "String", "int", "ZonedDateTime", "List");
+        assertThat(typeAliases.getAliasesMappedByName().get("String"))
+                .isEqualTo(TypeAlias.of("String", String.class));
 
-    public Type getType() {
-        return type;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TypeAlias alias = (TypeAlias) o;
-        return Objects.equals(name, alias.name) &&
-                Objects.equals(type, alias.type);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, type);
+        assertThat(typeAliases.getAliasesMappedByType()).isNotEmpty();
+        assertThat(typeAliases.getAliasesMappedByType())
+                .containsKeys(Object.class, String.class, int.class, ZonedDateTime.class, List.class);
+        assertThat(typeAliases.getAliasesMappedByType().get(String.class))
+                .isEqualTo(TypeAlias.of("String", String.class));
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
@@ -24,42 +24,88 @@
 
 package com.sabre.oss.yare.common.converter.aliases;
 
+import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 class TypeAliasesTest {
+    private TypeAliases typeAliases = new TypeAliases();
+
     @Test
-    void shouldInitializeTypeAliasesFromPropertiesFile() {
-        //when
-        TypeAliases typeAliases = new TypeAliases();
+    void shouldInitializeMapOfAliasesByNameProperly() {
+        //given /when /then
+        assertThat(typeAliases.getAliasesMappedByName().entrySet())
+                .containsExactlyInAnyOrder(
+                        getEntryWithNameKey("Object", Object.class),
+                        getEntryWithNameKey("String", String.class),
+                        getEntryWithNameKey("Integer", Integer.class),
+                        getEntryWithNameKey("Long", Long.class),
+                        getEntryWithNameKey("Double", Double.class),
+                        getEntryWithNameKey("Boolean", Boolean.class),
+                        getEntryWithNameKey("Byte", Byte.class),
+                        getEntryWithNameKey("Short", Short.class),
+                        getEntryWithNameKey("Character", Character.class),
+                        getEntryWithNameKey("Float", Float.class),
+                        getEntryWithNameKey("Void", Void.class),
+                        getEntryWithNameKey("int", int.class),
+                        getEntryWithNameKey("long", long.class),
+                        getEntryWithNameKey("double", double.class),
+                        getEntryWithNameKey("boolean", boolean.class),
+                        getEntryWithNameKey("byte", byte.class),
+                        getEntryWithNameKey("short", short.class),
+                        getEntryWithNameKey("char", char.class),
+                        getEntryWithNameKey("float", float.class),
+                        getEntryWithNameKey("void", void.class),
+                        getEntryWithNameKey("ZonedDateTime", ZonedDateTime.class),
+                        getEntryWithNameKey("List", List.class),
+                        getEntryWithNameKey("Map", Map.class),
+                        getEntryWithNameKey("Set", Set.class));
+    }
 
-        //then
-        assertThat(typeAliases.getAliasesMappedByName()).isNotEmpty();
-        assertThat(typeAliases.getAliasesMappedByName())
-                .containsOnlyKeys(
-                        "Integer", "Long", "Double", "Boolean", "Byte",
-                        "Short", "Character", "Float", "Void",
-                        "int", "long", "double", "boolean", "byte",
-                        "short", "char", "float", "void",
-                        "Object", "String", "ZonedDateTime", "List", "Map", "Set");
-        assertThat(typeAliases.getAliasesMappedByName().get("String"))
-                .isEqualTo(TypeAlias.of("String", String.class));
+    @Test
+    void shouldInitializeMapOfAliasesByTypeProperly() {
+        //given /when /then
+        assertThat(typeAliases.getAliasesMappedByType().entrySet())
+                .containsExactlyInAnyOrder(
+                        getEntryWithTypeKey("Object", Object.class),
+                        getEntryWithTypeKey("String", String.class),
+                        getEntryWithTypeKey("Integer", Integer.class),
+                        getEntryWithTypeKey("Long", Long.class),
+                        getEntryWithTypeKey("Double", Double.class),
+                        getEntryWithTypeKey("Boolean", Boolean.class),
+                        getEntryWithTypeKey("Byte", Byte.class),
+                        getEntryWithTypeKey("Short", Short.class),
+                        getEntryWithTypeKey("Character", Character.class),
+                        getEntryWithTypeKey("Float", Float.class),
+                        getEntryWithTypeKey("Void", Void.class),
+                        getEntryWithTypeKey("int", int.class),
+                        getEntryWithTypeKey("long", long.class),
+                        getEntryWithTypeKey("double", double.class),
+                        getEntryWithTypeKey("boolean", boolean.class),
+                        getEntryWithTypeKey("byte", byte.class),
+                        getEntryWithTypeKey("short", short.class),
+                        getEntryWithTypeKey("char", char.class),
+                        getEntryWithTypeKey("float", float.class),
+                        getEntryWithTypeKey("void", void.class),
+                        getEntryWithTypeKey("ZonedDateTime", ZonedDateTime.class),
+                        getEntryWithTypeKey("List", List.class),
+                        getEntryWithTypeKey("Map", Map.class),
+                        getEntryWithTypeKey("Set", Set.class));
+    }
 
-        assertThat(typeAliases.getAliasesMappedByType()).isNotEmpty();
-        assertThat(typeAliases.getAliasesMappedByType())
-                .containsOnlyKeys(
-                        Integer.class, Long.class, Double.class, Boolean.class, Byte.class,
-                        Short.class, Character.class, Float.class, Void.class,
-                        int.class, long.class, double.class, boolean.class, byte.class,
-                        short.class, char.class, float.class, void.class,
-                        Object.class, String.class, ZonedDateTime.class, List.class, Map.class, Set.class);
-        assertThat(typeAliases.getAliasesMappedByType().get(String.class))
-                .isEqualTo(TypeAlias.of("String", String.class));
+    private MapEntry<String, TypeAlias> getEntryWithNameKey(String typeName, Class<?> type) {
+        return entry(typeName, TypeAlias.of(typeName, type));
+    }
+
+    private MapEntry<Type, TypeAlias> getEntryWithTypeKey(String typeName, Class<?> type) {
+        return entry(type, TypeAlias.of(typeName, type));
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,13 +42,23 @@ class TypeAliasesTest {
         //then
         assertThat(typeAliases.getAliasesMappedByName()).isNotEmpty();
         assertThat(typeAliases.getAliasesMappedByName())
-                .containsKeys("Object", "String", "int", "ZonedDateTime", "List");
+                .containsOnlyKeys(
+                        "Integer", "Long", "Double", "Boolean", "Byte",
+                        "Short", "Character", "Float", "Void",
+                        "int", "long", "double", "boolean", "byte",
+                        "short", "char", "float", "void",
+                        "Object", "String", "ZonedDateTime", "List", "Map", "Set");
         assertThat(typeAliases.getAliasesMappedByName().get("String"))
                 .isEqualTo(TypeAlias.of("String", String.class));
 
         assertThat(typeAliases.getAliasesMappedByType()).isNotEmpty();
         assertThat(typeAliases.getAliasesMappedByType())
-                .containsKeys(Object.class, String.class, int.class, ZonedDateTime.class, List.class);
+                .containsOnlyKeys(
+                        Integer.class, Long.class, Double.class, Boolean.class, Byte.class,
+                        Short.class, Character.class, Float.class, Void.class,
+                        int.class, long.class, double.class, boolean.class, byte.class,
+                        short.class, char.class, float.class, void.class,
+                        Object.class, String.class, ZonedDateTime.class, List.class, Map.class, Set.class);
         assertThat(typeAliases.getAliasesMappedByType().get(String.class))
                 .isEqualTo(TypeAlias.of("String", String.class));
     }

--- a/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithBuildInObjectTypes.xml
+++ b/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithBuildInObjectTypes.xml
@@ -26,8 +26,8 @@
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <yare:Rule xmlns:custom="http://example.sabre.com/custom/schema"
            xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
-    <yare:Attribute name="ruleName" type="java.lang.String" value="RuleName"/>
-    <yare:Attribute name="ruleType" type="java.lang.String" value="RuleType"/>
+    <yare:Attribute name="ruleName" type="String" value="RuleName"/>
+    <yare:Attribute name="ruleType" type="String" value="RuleType"/>
     <yare:Attribute name="startDate" type="java.time.ZonedDateTime" value="2016-06-30T00:00+01:00[Europe/London]"/>
     <yare:Attribute name="expireDate" type="java.time.ZonedDateTime" value="2017-01-02T00:00Z"/>
     <yare:Attribute name="someVariable" type="java.lang.Boolean" value="true"/>
@@ -80,12 +80,12 @@
     </yare:Predicate>
     <yare:Action name="ActionName1">
         <yare:Parameter name="ParameterName1">
-            <yare:Values type="java.lang.String">
+            <yare:Values type="String">
                 <yare:Value>anyValueA</yare:Value>
             </yare:Values>
         </yare:Parameter>
         <yare:Parameter name="ParameterName2">
-            <yare:Values type="java.lang.String">
+            <yare:Values type="String">
                 <yare:Value>anyValueB</yare:Value>
             </yare:Values>
         </yare:Parameter>

--- a/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithBuildInObjectTypes.xml
+++ b/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithBuildInObjectTypes.xml
@@ -28,18 +28,18 @@
            xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
     <yare:Attribute name="ruleName" type="String" value="RuleName"/>
     <yare:Attribute name="ruleType" type="String" value="RuleType"/>
-    <yare:Attribute name="startDate" type="java.time.ZonedDateTime" value="2016-06-30T00:00+01:00[Europe/London]"/>
-    <yare:Attribute name="expireDate" type="java.time.ZonedDateTime" value="2017-01-02T00:00Z"/>
-    <yare:Attribute name="someVariable" type="java.lang.Boolean" value="true"/>
+    <yare:Attribute name="startDate" type="ZonedDateTime" value="2016-06-30T00:00+01:00[Europe/London]"/>
+    <yare:Attribute name="expireDate" type="ZonedDateTime" value="2017-01-02T00:00Z"/>
+    <yare:Attribute name="someVariable" type="Boolean" value="true"/>
     <yare:Fact name="fact" type="com.sabre.oss.yare.serializer.SimpleFact"/>
     <yare:Fact name="otherFact" type="com.sabre.oss.yare.serializer.OtherFact"/>
     <yare:Predicate>
         <yare:And>
             <yare:And>
-                <yare:Value type="java.lang.Boolean">false</yare:Value>
+                <yare:Value type="Boolean">false</yare:Value>
                 <yare:Operator type="EQUALS">
                     <yare:Value>${someVariable}</yare:Value>
-                    <yare:Value type="java.lang.Boolean">false</yare:Value>
+                    <yare:Value type="Boolean">false</yare:Value>
                 </yare:Operator>
                 <yare:Operator type="EQUALS">
                     <yare:Value>${fact.boolField}</yare:Value>
@@ -47,20 +47,20 @@
                 </yare:Operator>
             </yare:And>
             <yare:Or>
-                <yare:Value type="java.lang.Boolean">false</yare:Value>
+                <yare:Value type="Boolean">false</yare:Value>
                 <yare:Operator type="EQUALS">
                     <yare:Value>${someVariable}</yare:Value>
-                    <yare:Value type="java.lang.Boolean">false</yare:Value>
+                    <yare:Value type="Boolean">false</yare:Value>
                 </yare:Operator>
             </yare:Or>
             <yare:Not>
-                <yare:Value type="java.lang.Boolean">false</yare:Value>
+                <yare:Value type="Boolean">false</yare:Value>
             </yare:Not>
             <yare:Operator type="EQUALS">
                 <yare:Value>${someVariable}</yare:Value>
-                <yare:Value type="java.lang.Boolean">false</yare:Value>
+                <yare:Value type="Boolean">false</yare:Value>
             </yare:Operator>
-            <yare:Function name="someFunction" returnType="java.lang.Boolean">
+            <yare:Function name="someFunction" returnType="Boolean">
                 <yare:Parameter name="funcArg1">
                     <yare:Value>value</yare:Value>
                 </yare:Parameter>
@@ -68,14 +68,14 @@
                     <yare:Value>${fact}</yare:Value>
                 </yare:Parameter>
                 <yare:Parameter name="funcArg3">
-                    <yare:Function name="otherFunction" returnType="java.lang.Long">
+                    <yare:Function name="otherFunction" returnType="Long">
                         <yare:Parameter name="param">
                             <yare:Value>${fact.stringField}</yare:Value>
                         </yare:Parameter>
                     </yare:Function>
                 </yare:Parameter>
             </yare:Function>
-            <yare:Value type="java.lang.Boolean">false</yare:Value>
+            <yare:Value type="Boolean">false</yare:Value>
         </yare:And>
     </yare:Predicate>
     <yare:Action name="ActionName1">

--- a/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithCustomObjectTypes.xml
+++ b/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithCustomObjectTypes.xml
@@ -25,11 +25,11 @@
 
 <yare:Rule xmlns:custom="http://example.sabre.com/custom/schema"
            xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
-    <yare:Attribute name="ruleName" value="ruleOperatingOnCustomObjectTypes" type="java.lang.String"/>
-    <yare:Fact name="fact" type="java.lang.Object"/>
+    <yare:Attribute name="ruleName" value="ruleOperatingOnCustomObjectTypes" type="String"/>
+    <yare:Fact name="fact" type="Object"/>
     <yare:Predicate>
         <yare:Or>
-            <yare:Function name="functionTakingCustomObjectsAsArguments" returnType="java.lang.Object">
+            <yare:Function name="functionTakingCustomObjectsAsArguments" returnType="Object">
                 <yare:Parameter name="object">
                     <yare:CustomValue type="com.sabre.oss.yare.serializer.ConverterTest.Isbn">
                         <custom:Isbn>


### PR DESCRIPTION
Problem description:
Right now in XML it is needed to provide full type name. For standard types like: java.lang.String, java.lang.Integer we would like to write String, Integer.