### PR TITLE
Use OpenJDK 10 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script: chmod +x ./.travis/build.sh && ./.travis/build.sh
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10


### PR DESCRIPTION
Travis CI considers OracleJDK 10 as deprecated. 