### PR TITLE
Improve Undefined null value marshalling in XML converter

### DIFF
--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/UndefinedTypeConverter.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/UndefinedTypeConverter.java
@@ -24,38 +24,23 @@
 
 package com.sabre.oss.yare.common.converter;
 
-import static java.util.Arrays.asList;
+import com.sabre.oss.yare.core.model.Expression;
 
-/**
- * A utility class which configures {@link TypeConverter} with the default set of type converters.
- */
-public abstract class DefaultTypeConverters {
-    private static final TypeConverter DEFAULT_AGGREGATE_TYPE_CONVERTER = prepareDefaultTypeConverter();
+import java.lang.reflect.Type;
 
-    /**
-     * Returns pre-configured aggregate {@link TypeConverter}.
-     *
-     * @return {@link TypeConverter}
-     */
-    public static TypeConverter getDefaultTypeConverter() {
-        return DEFAULT_AGGREGATE_TYPE_CONVERTER;
+public class UndefinedTypeConverter implements TypeConverter {
+    @Override
+    public boolean isApplicable(Type type) {
+        return Expression.UNDEFINED.equals(type);
     }
 
-    /**
-     * Prepares default aggregate type converter that is able to handle simple types.
-     *
-     * @return aggregated {@link TypeConverter}
-     */
-    private static TypeConverter prepareDefaultTypeConverter() {
-        return new ChainedTypeConverter(asList(
-                new TypeTypeConverter(),
-                new StringTypeConverter(),
-                new BooleanTypeConverter(),
-                new IntegerTypeConverter(),
-                new LongTypeConverter(),
-                new BigDecimalTypeConverter(),
-                new ZonedDateTimeConverter(),
-                new UndefinedTypeConverter()
-        ));
+    @Override
+    public Object fromString(Type type, String value) {
+        return null;
+    }
+
+    @Override
+    public String toString(Type type, Object value) {
+        return StringTypeConverter.NULL_LITERAL;
     }
 }

--- a/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
+++ b/yare-model-converters/src/main/java/com/sabre/oss/yare/common/converter/aliases/ClassUtils.java
@@ -45,7 +45,8 @@ final class ClassUtils {
                 }
             };
 
-    private ClassUtils() { }
+    private ClassUtils() {
+    }
 
     static Class<?> forName(String name) {
         return Stream.of(

--- a/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
+++ b/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
@@ -50,4 +50,4 @@ BigDecimal=java.math.BigDecimal
 List=java.util.List
 Map=java.util.Map
 Set=java.util.Set
-Undefined=com.sabre.oss.yare.core.model.Expression$Undefined
+Expression.Undefined=com.sabre.oss.yare.core.model.Expression$Undefined

--- a/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
+++ b/yare-model-converters/src/main/resources/com/sabre/oss/yare/common/converter/aliases/typeAliases.properties
@@ -50,3 +50,4 @@ BigDecimal=java.math.BigDecimal
 List=java.util.List
 Map=java.util.Map
 Set=java.util.Set
+Undefined=com.sabre.oss.yare.core.model.Expression$Undefined

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/DefaultTypeConvertersTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/DefaultTypeConvertersTest.java
@@ -24,6 +24,7 @@
 
 package com.sabre.oss.yare.common.converter;
 
+import com.sabre.oss.yare.core.model.Expression;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -62,7 +63,8 @@ class DefaultTypeConvertersTest {
                 Long.class,
                 String.class,
                 Type.class,
-                ZonedDateTime.class
+                ZonedDateTime.class,
+                Expression.UNDEFINED
         );
     }
 
@@ -90,7 +92,8 @@ class DefaultTypeConvertersTest {
                 Arguments.of(Long.class, "123", 123L),
                 Arguments.of(String.class, "test", "test"),
                 Arguments.of(Type.class, "Object", Object.class),
-                Arguments.of(ZonedDateTime.class, "2014-12-02T10:45:30+02:00", ZonedDateTime.parse("2014-12-02T10:45:30+02:00"))
+                Arguments.of(ZonedDateTime.class, "2014-12-02T10:45:30+02:00", ZonedDateTime.parse("2014-12-02T10:45:30+02:00")),
+                Arguments.of(Expression.UNDEFINED, "@null", null)
         );
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/UndefinedTypeConverterTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/UndefinedTypeConverterTest.java
@@ -24,38 +24,38 @@
 
 package com.sabre.oss.yare.common.converter;
 
-import static java.util.Arrays.asList;
+import com.sabre.oss.yare.core.model.Expression;
+import org.junit.jupiter.api.Test;
 
-/**
- * A utility class which configures {@link TypeConverter} with the default set of type converters.
- */
-public abstract class DefaultTypeConverters {
-    private static final TypeConverter DEFAULT_AGGREGATE_TYPE_CONVERTER = prepareDefaultTypeConverter();
+import static org.assertj.core.api.Assertions.assertThat;
 
-    /**
-     * Returns pre-configured aggregate {@link TypeConverter}.
-     *
-     * @return {@link TypeConverter}
-     */
-    public static TypeConverter getDefaultTypeConverter() {
-        return DEFAULT_AGGREGATE_TYPE_CONVERTER;
+class UndefinedTypeConverterTest {
+    private final UndefinedTypeConverter converter = new UndefinedTypeConverter();
+
+    @Test
+    void shouldBeApplicableForUndefinedType() {
+        // when
+        boolean applicable = converter.isApplicable(Expression.UNDEFINED);
+
+        // then
+        assertThat(applicable).isTrue();
     }
 
-    /**
-     * Prepares default aggregate type converter that is able to handle simple types.
-     *
-     * @return aggregated {@link TypeConverter}
-     */
-    private static TypeConverter prepareDefaultTypeConverter() {
-        return new ChainedTypeConverter(asList(
-                new TypeTypeConverter(),
-                new StringTypeConverter(),
-                new BooleanTypeConverter(),
-                new IntegerTypeConverter(),
-                new LongTypeConverter(),
-                new BigDecimalTypeConverter(),
-                new ZonedDateTimeConverter(),
-                new UndefinedTypeConverter()
-        ));
+    @Test
+    void shouldReturnNullWhenFromStringConversion() {
+        // when
+        Object converted = converter.fromString(null, null);
+
+        // then
+        assertThat(converted).isNull();
+    }
+
+    @Test
+    void shouldReturnNullLiteralWhenToStringConversion() {
+        // when
+        String converted = converter.toString(null, null);
+
+        // then
+        assertThat(converted).isEqualTo(StringTypeConverter.NULL_LITERAL);
     }
 }

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
@@ -24,6 +24,7 @@
 
 package com.sabre.oss.yare.common.converter.aliases;
 
+import com.sabre.oss.yare.core.model.Expression;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +70,8 @@ class TypeAliasesTest {
                         getEntryWithNameKey("BigDecimal", BigDecimal.class),
                         getEntryWithNameKey("List", List.class),
                         getEntryWithNameKey("Map", Map.class),
-                        getEntryWithNameKey("Set", Set.class));
+                        getEntryWithNameKey("Set", Set.class),
+                        getEntryWithNameKey("Undefined", Expression.UNDEFINED));
     }
 
     @Test
@@ -101,7 +103,8 @@ class TypeAliasesTest {
                         getEntryWithTypeKey("BigDecimal", BigDecimal.class),
                         getEntryWithTypeKey("List", List.class),
                         getEntryWithTypeKey("Map", Map.class),
-                        getEntryWithTypeKey("Set", Set.class));
+                        getEntryWithTypeKey("Set", Set.class),
+                        getEntryWithTypeKey("Undefined", Expression.UNDEFINED));
     }
 
     private MapEntry<String, TypeAlias> getEntryWithNameKey(String typeName, Class<?> type) {

--- a/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
+++ b/yare-model-converters/src/test/java/com/sabre/oss/yare/common/converter/aliases/TypeAliasesTest.java
@@ -71,7 +71,7 @@ class TypeAliasesTest {
                         getEntryWithNameKey("List", List.class),
                         getEntryWithNameKey("Map", Map.class),
                         getEntryWithNameKey("Set", Set.class),
-                        getEntryWithNameKey("Undefined", Expression.UNDEFINED));
+                        getEntryWithNameKey("Expression.Undefined", Expression.UNDEFINED));
     }
 
     @Test
@@ -104,7 +104,7 @@ class TypeAliasesTest {
                         getEntryWithTypeKey("List", List.class),
                         getEntryWithTypeKey("Map", Map.class),
                         getEntryWithTypeKey("Set", Set.class),
-                        getEntryWithTypeKey("Undefined", Expression.UNDEFINED));
+                        getEntryWithTypeKey("Expression.Undefined", Expression.UNDEFINED));
     }
 
     private MapEntry<String, TypeAlias> getEntryWithNameKey(String typeName, Class<?> type) {

--- a/yare-serializer/yare-serializer-json/src/test/java/com/sabre/oss/yare/serializer/json/mapper/json/PredicateConverterTest.java
+++ b/yare-serializer/yare-serializer-json/src/test/java/com/sabre/oss/yare/serializer/json/mapper/json/PredicateConverterTest.java
@@ -27,10 +27,10 @@ package com.sabre.oss.yare.serializer.json.mapper.json;
 import com.sabre.oss.yare.common.converter.DefaultTypeConverters;
 import com.sabre.oss.yare.core.model.Expression;
 import com.sabre.oss.yare.serializer.json.model.Function;
-import com.sabre.oss.yare.serializer.json.model.*;
 import com.sabre.oss.yare.serializer.json.model.Operator;
 import com.sabre.oss.yare.serializer.json.model.Value;
 import com.sabre.oss.yare.serializer.json.model.Values;
+import com.sabre.oss.yare.serializer.json.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -73,7 +73,7 @@ class PredicateConverterTest {
 
             Value expected = new Value()
                     .withValue(100)
-                    .withType(Expression.Undefined.class.getCanonicalName());
+                    .withType("Undefined");
             assertThat(operand).isEqualTo(expected);
         }
     }
@@ -144,7 +144,7 @@ class PredicateConverterTest {
             Operand operand = predicateConverter.convert(toConvert);
 
             Values expected = new Values()
-                    .withType(Expression.Undefined.class.getCanonicalName())
+                    .withType("Undefined")
                     .withValues();
             assertThat(operand).isEqualTo(expected);
         }

--- a/yare-serializer/yare-serializer-json/src/test/java/com/sabre/oss/yare/serializer/json/mapper/json/PredicateConverterTest.java
+++ b/yare-serializer/yare-serializer-json/src/test/java/com/sabre/oss/yare/serializer/json/mapper/json/PredicateConverterTest.java
@@ -73,7 +73,7 @@ class PredicateConverterTest {
 
             Value expected = new Value()
                     .withValue(100)
-                    .withType("Undefined");
+                    .withType("Expression.Undefined");
             assertThat(operand).isEqualTo(expected);
         }
     }
@@ -144,7 +144,7 @@ class PredicateConverterTest {
             Operand operand = predicateConverter.convert(toConvert);
 
             Values expected = new Values()
-                    .withType("Undefined")
+                    .withType("Expression.Undefined")
                     .withValues();
             assertThat(operand).isEqualTo(expected);
         }

--- a/yare-serializer/yare-serializer-json/src/test/resources/json/rule.json
+++ b/yare-serializer/yare-serializer-json/src/test/resources/json/rule.json
@@ -78,7 +78,7 @@
                       "name": "param-1",
                       "function": {
                         "name": "function-2",
-                        "returnType": "com.sabre.oss.yare.core.model.Expression.Undefined",
+                        "returnType": "Undefined",
                         "parameters": []
                       }
                     }
@@ -125,7 +125,7 @@
             "is-null": [
               {
                 "value": null,
-                "type": "com.sabre.oss.yare.core.model.Expression.Undefined"
+                "type": "Undefined"
               }
             ]
           }
@@ -155,7 +155,7 @@
           "name": "param-3",
           "function": {
             "name": "function-4",
-            "returnType": "com.sabre.oss.yare.core.model.Expression.Undefined",
+            "returnType": "Undefined",
             "parameters": []
           }
         }

--- a/yare-serializer/yare-serializer-json/src/test/resources/json/rule.json
+++ b/yare-serializer/yare-serializer-json/src/test/resources/json/rule.json
@@ -78,7 +78,7 @@
                       "name": "param-1",
                       "function": {
                         "name": "function-2",
-                        "returnType": "Undefined",
+                        "returnType": "Expression.Undefined",
                         "parameters": []
                       }
                     }
@@ -125,7 +125,7 @@
             "is-null": [
               {
                 "value": null,
-                "type": "Undefined"
+                "type": "Expression.Undefined"
               }
             ]
           }
@@ -155,7 +155,7 @@
           "name": "param-3",
           "function": {
             "name": "function-4",
-            "returnType": "Undefined",
+            "returnType": "Expression.Undefined",
             "parameters": []
           }
         }

--- a/yare-serializer/yare-serializer-json/src/test/resources/yaml/rule.yml
+++ b/yare-serializer/yare-serializer-json/src/test/resources/yaml/rule.yml
@@ -52,7 +52,7 @@ predicate:
           - name: "param-1"
             function:
               name: "function-2"
-              returnType: "Undefined"
+              returnType: "Expression.Undefined"
               parameters: []
   - function:
       name: "function-3"
@@ -72,7 +72,7 @@ predicate:
   - not:
     - is-null:
       - value: null
-        type: "Undefined"
+        type: "Expression.Undefined"
 actions:
 - name: "action-name"
   parameters:
@@ -86,5 +86,5 @@ actions:
   - name: "param-3"
     function:
       name: "function-4"
-      returnType: "Undefined"
+      returnType: "Expression.Undefined"
       parameters: []

--- a/yare-serializer/yare-serializer-json/src/test/resources/yaml/rule.yml
+++ b/yare-serializer/yare-serializer-json/src/test/resources/yaml/rule.yml
@@ -52,7 +52,7 @@ predicate:
           - name: "param-1"
             function:
               name: "function-2"
-              returnType: "com.sabre.oss.yare.core.model.Expression.Undefined"
+              returnType: "Undefined"
               parameters: []
   - function:
       name: "function-3"
@@ -72,7 +72,7 @@ predicate:
   - not:
     - is-null:
       - value: null
-        type: "com.sabre.oss.yare.core.model.Expression.Undefined"
+        type: "Undefined"
 actions:
 - name: "action-name"
   parameters:
@@ -86,5 +86,5 @@ actions:
   - name: "param-3"
     function:
       name: "function-4"
-      returnType: "com.sabre.oss.yare.core.model.Expression.Undefined"
+      returnType: "Undefined"
       parameters: []

--- a/yare-serializer/yare-serializer-xml/src/main/java/com/sabre/oss/yare/serializer/xml/mapper/converter/rule/NodeConverter.java
+++ b/yare-serializer/yare-serializer-xml/src/main/java/com/sabre/oss/yare/serializer/xml/mapper/converter/rule/NodeConverter.java
@@ -77,12 +77,8 @@ class NodeConverter {
         return (name, input) -> {
             String typeName = input.getType();
             String value = input.getValue();
-            if (typeName != null) {
-                Type type = typeConverter.fromString(Type.class, typeName);
-                return valueOf(name, type, typeConverter.fromString(type, value));
-            } else {
-                return valueOf(name, String.class, value);
-            }
+            Type type = typeName != null ? typeConverter.fromString(Type.class, typeName) : String.class;
+            return valueOf(name, type, typeConverter.fromString(type, value));
         };
     }
 

--- a/yare-serializer/yare-serializer-xml/src/main/java/com/sabre/oss/yare/serializer/xml/mapper/converter/xml/ExpressionConverter.java
+++ b/yare-serializer/yare-serializer-xml/src/main/java/com/sabre/oss/yare/serializer/xml/mapper/converter/xml/ExpressionConverter.java
@@ -75,12 +75,10 @@ class ExpressionConverter {
         Expression.Value value = expression.as(Expression.Value.class);
         if (value != null) {
             String type = typeConverter.toString(Type.class, value.getType());
-            if (value.getValue() != null) {
-                if (typeConverter.isApplicable(value.getType())) {
-                    return new ValueSer()
-                            .withType(String.class.equals(value.getType()) ? null : type)
-                            .withValue(typeConverter.toString(value.getType(), value.getValue()));
-                }
+            if (typeConverter.isApplicable(value.getType())) {
+                return new ValueSer()
+                        .withType(String.class.equals(value.getType()) ? null : type)
+                        .withValue(typeConverter.toString(value.getType(), value.getValue()));
             }
             return new CustomValueSer()
                     .withType(type)

--- a/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/RuleToXmlConverterTest.java
+++ b/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/RuleToXmlConverterTest.java
@@ -60,6 +60,8 @@ class RuleToXmlConverterTest {
     private static final ObjectFactory objectFactory = new ObjectFactory();
     private static final String validXmlRuleWithBuildInObjectTypes = substringAfterLast(getResourceAsString("/serializer/validXmlRuleWithBuildInObjectTypes.xml"), "-->");
     private static final String validXmlRuleWithCustomObjectTypes = substringAfterLast(getResourceAsString("/serializer/validXmlRuleWithCustomObjectTypes.xml"), "-->");
+    private static final String validXmlRuleWithNullUndefinedValue = substringAfterLast(getResourceAsString("/serializer/validXmlRuleWithNullUndefinedValue.xml"), "-->");
+    private static final String validXmlRuleWithNullStringValue = substringAfterLast(getResourceAsString("/serializer/validXmlRuleWithNullStringValue.xml"), "-->");
 
     private final ToRuleConverter toRuleConverter = new ToRuleConverter(DefaultTypeConverters.getDefaultTypeConverter());
     private final ToXmlConverter toXmlConverter = new ToXmlConverter(DefaultTypeConverters.getDefaultTypeConverter());
@@ -96,6 +98,30 @@ class RuleToXmlConverterTest {
     }
 
     @Test
+    void shouldMarshallValidRuleWithNullUndefinedValue() {
+        // given
+        Rule ruleObject = toRuleConverter.map(TestRuleFactory.constructValidRuleWithNullUndefinedValue());
+
+        // when
+        String ruleAsString = converter.marshal(ruleObject);
+
+        // then
+        assertThat(ruleAsString).isXmlEqualTo(validXmlRuleWithNullUndefinedValue);
+    }
+
+    @Test
+    void shouldMarshallValidRuleWithNullStringValue() {
+        // given
+        Rule ruleObject = toRuleConverter.map(TestRuleFactory.constructValidRuleWithNullStringValue());
+
+        // when
+        String ruleAsString = converter.marshal(ruleObject);
+
+        // then
+        assertThat(ruleAsString).isXmlEqualTo(validXmlRuleWithNullStringValue);
+    }
+
+    @Test
     void shouldUnmarshalValidRuleWithBuildInObjectTypes() {
         // given
         Rule validRule = toRuleConverter.map(TestRuleFactory.constructValidRuleWithBuildInObjectTypes());
@@ -118,6 +144,30 @@ class RuleToXmlConverterTest {
 
         // then
         assertThat(ruleObject.getAttributes()).containsAll(validRule.getAttributes());
+        assertThat(ruleObject).isEqualTo(validRule);
+    }
+
+    @Test
+    void shouldUnmarshalValidRuleWithNullUndefinedValue() {
+        // given
+        Rule validRule = toRuleConverter.map(TestRuleFactory.constructValidRuleWithNullUndefinedValue());
+
+        // when
+        Rule ruleObject = converter.unmarshal(validXmlRuleWithNullUndefinedValue);
+
+        // then
+        assertThat(ruleObject).isEqualTo(validRule);
+    }
+
+    @Test
+    void shouldUnmarshalValidRuleWithNullStringValue() {
+        // given
+        Rule validRule = toRuleConverter.map(TestRuleFactory.constructValidRuleWithNullStringValue());
+
+        // when
+        Rule ruleObject = converter.unmarshal(validXmlRuleWithNullStringValue);
+
+        // then
         assertThat(ruleObject).isEqualTo(validRule);
     }
 

--- a/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/TestRuleFactory.java
+++ b/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/TestRuleFactory.java
@@ -207,6 +207,20 @@ final class TestRuleFactory {
                         .withParameter(operands));
     }
 
+    static RuleSer constructValidRuleWithNullUndefinedValue() {
+        return new RuleSer()
+                .withPredicate(new PredicateSer()
+                        .withValue(new ValueSer().withType("Undefined").withValue("@null"))
+                );
+    }
+
+    static RuleSer constructValidRuleWithNullStringValue() {
+        return new RuleSer()
+                .withPredicate(new PredicateSer()
+                        .withValue(new ValueSer().withValue("@null"))
+                );
+    }
+
     @XmlRootElement(namespace = "http://example.sabre.com/custom/schema", name = "Isbn")
     static class Isbn {
         private String code;

--- a/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/TestRuleFactory.java
+++ b/yare-serializer/yare-serializer-xml/src/test/java/com/sabre/oss/yare/serializer/xml/TestRuleFactory.java
@@ -210,7 +210,7 @@ final class TestRuleFactory {
     static RuleSer constructValidRuleWithNullUndefinedValue() {
         return new RuleSer()
                 .withPredicate(new PredicateSer()
-                        .withValue(new ValueSer().withType("Undefined").withValue("@null"))
+                        .withValue(new ValueSer().withType("Expression.Undefined").withValue("@null"))
                 );
     }
 

--- a/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullStringValue.xml
+++ b/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullStringValue.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright 2018 Sabre GLBL Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  ~
+  -->
+
+<!--suppress XmlUnusedNamespaceDeclaration -->
+<yare:Rule xmlns:custom="http://example.sabre.com/custom/schema"
+           xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
+    <yare:Predicate>
+        <yare:Value>@null</yare:Value>
+    </yare:Predicate>
+</yare:Rule>

--- a/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullUndefinedValue.xml
+++ b/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullUndefinedValue.xml
@@ -27,6 +27,6 @@
 <yare:Rule xmlns:custom="http://example.sabre.com/custom/schema"
            xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
     <yare:Predicate>
-        <yare:Value type="Undefined">@null</yare:Value>
+        <yare:Value type="Expression.Undefined">@null</yare:Value>
     </yare:Predicate>
 </yare:Rule>

--- a/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullUndefinedValue.xml
+++ b/yare-serializer/yare-serializer-xml/src/test/resources/serializer/validXmlRuleWithNullUndefinedValue.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright 2018 Sabre GLBL Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  ~
+  -->
+
+<!--suppress XmlUnusedNamespaceDeclaration -->
+<yare:Rule xmlns:custom="http://example.sabre.com/custom/schema"
+           xmlns:yare="http://www.sabre.com/schema/oss/yare/rules/v1">
+    <yare:Predicate>
+        <yare:Value type="Undefined">@null</yare:Value>
+    </yare:Predicate>
+</yare:Rule>


### PR DESCRIPTION
Solution for bug #48. 

Currently null value of _Expression.Undefined_ type can't be marshalled to `<yare:Value>@null</yare:Value>` because null _String_ value is expressed identically in XML. During unmarshalling it wouldn't be possible to distinguish whether the initial type was _String_ or _Expression.Undefined_.

I have proposed minor change where objects of type _Expression.Undefined_ are marshalled to Value instead of CustomValue. To unify typing I have added alias for this predefined type.

Let me know what you are thinking about this solution. Thanks.

