### PR TITLE
Jackson and  com.puppycrawl.tools:checkstyle dependencies update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.11.0</log4j.version>
-        <jackson2.version>2.9.6</jackson2.version>
+        <jackson2.version>2.9.8</jackson2.version>
         <jaxb.version>2.3.0</jaxb.version>
         <assertj.version>3.10.0</assertj.version>
         <jmh.version>1.20</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.8</version>
+                            <version>8.18</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
Due to several vulnerabilities in Jackson and com.puppycrawl.tools:checkstyle it is needed to update those dependencies:

- Jackson 2.9.6 -> 2.9.8
- com.puppycrawl.tools:checkstyle 8.8 -> 8.18