### PR TITLE
Improve cuncurrent field referring

### DIFF
--- a/yare-engine/src/main/java/com/sabre/oss/yare/engine/executor/runtime/value/FieldReferringClassFactory.java
+++ b/yare-engine/src/main/java/com/sabre/oss/yare/engine/executor/runtime/value/FieldReferringClassFactory.java
@@ -32,19 +32,20 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.sabre.oss.yare.engine.executor.runtime.value.TypeUtils.getRawType;
 import static com.sabre.oss.yare.engine.executor.runtime.value.TypeUtils.isCollection;
 
 public abstract class FieldReferringClassFactory {
     private static final Logger log = LoggerFactory.getLogger(FieldReferringClassFactory.class);
-    private static final Map<String, ValueProvider> valueProviders = new HashMap<>();
+    private static final Map<String, ValueProvider> valueProviders = new ConcurrentHashMap<>();
     private static final ClassPool classPool = createClassPool();
 
     private FieldReferringClassFactory() {
     }
 
-    public static synchronized ValueProvider create(Class<?> targetClass, String identifier, String propertyName) {
+    public static ValueProvider create(Class<?> targetClass, String identifier, String propertyName) {
         String key = nameForType(targetClass, propertyName) + '$' + identifier;
         return valueProviders.computeIfAbsent(key, k -> createFieldReferringInstance(targetClass, identifier, propertyName));
     }

--- a/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
+++ b/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
@@ -1,0 +1,164 @@
+package com.sabre.oss.yare.performance.suits;
+
+import com.sabre.oss.yare.core.RuleSession;
+import com.sabre.oss.yare.core.RulesEngine;
+import com.sabre.oss.yare.core.RulesEngineBuilder;
+import com.sabre.oss.yare.core.RulesRepository;
+import com.sabre.oss.yare.core.model.Rule;
+import com.sabre.oss.yare.dsl.Expression;
+import com.sabre.oss.yare.dsl.RuleDsl;
+import com.sabre.oss.yare.engine.executor.DefaultRulesExecutorBuilder;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.sabre.oss.yare.invoker.java.MethodCallMetadata.method;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MultithreadedTest {
+
+    @Test
+    public void launchBenchmark() throws Exception {
+        new Runner(
+                new OptionsBuilder().include(MultithreadedTest.class.getSimpleName())
+                        .shouldFailOnError(true)
+                        .mode(Mode.AverageTime)
+                        .timeUnit(TimeUnit.MILLISECONDS)
+                        .warmupIterations(2)
+                        .warmupTime(TimeValue.seconds(2))
+                        .measurementIterations(5)
+                        .measurementTime(TimeValue.seconds(10))
+                        .threads(Runtime.getRuntime().availableProcessors())
+                        .forks(1)
+                        .jvmArgs("-server", "-Xms2048M", "-Xmx2048M", "-XX:+UseG1GC")
+                        .shouldDoGC(true)
+                        .build()
+        ).run();
+    }
+
+    @Benchmark
+    public void benchmark(EngineState state, FactsState threadState) {
+        //given
+        String uri = UUID.randomUUID().toString();
+        RuleSession session = state.engine.createSession(uri);
+        //when
+        ArrayList<Object> result = session.execute(new ArrayList<>(), threadState.facts);
+        //then
+        int expectedResultSize = EngineState.NUMBER_OF_RULES * FactsState.NUMBER_OF_FACTS;
+        assertThat(result.size()).isEqualTo(expectedResultSize);
+    }
+
+    @State(Scope.Thread)
+    public static class FactsState {
+        public static int NUMBER_OF_FACTS = 1000;
+        private List<SimpleFact> facts;
+
+        @Setup(Level.Invocation)
+        public void init() {
+            facts = IntStream
+                    .range(0, NUMBER_OF_FACTS)
+                    .mapToObj(i -> new SimpleFact("1"))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class EngineState {
+        public static int NUMBER_OF_RULES = 500;
+        private RulesEngine engine;
+
+        @Setup(Level.Invocation)
+        public void init() {
+            engine = new RulesEngineBuilder()
+                    .withRulesRepository(initializeRuleRepository(NUMBER_OF_RULES))
+                    .withRulesExecutorBuilder(new DefaultRulesExecutorBuilder())
+                    .withActionMapping("collectValueAction",
+                            method(new CollectValueAction(), (action) -> action.execute(null, null)))
+                    .build();
+        }
+
+        static RulesRepository initializeRuleRepository(int testRuleCount) {
+            RulesRepository rulesRepository = mock(RulesRepository.class);
+            when(rulesRepository.get(anyString())).thenReturn(createTestRules(testRuleCount));
+            return rulesRepository;
+        }
+
+        static List<Rule> createTestRules(final int testRuleCount) {
+            return IntStream
+                    .range(0, testRuleCount)
+                    .mapToObj(EngineState::createRule)
+                    .collect(Collectors.toList());
+        }
+
+        static Rule createRule(int index) {
+            return RuleDsl.ruleBuilder()
+                    .name(String.valueOf(index))
+                    .fact("simpleStringValueFact", SimpleFact.class)
+                    .priority(0L)
+                    .predicate(
+                            RuleDsl.and(
+                                    IntStream.range(0, 500).mapToObj(x -> RuleDsl.equal(
+                                            RuleDsl.value("${simpleStringValueFact.value}"),
+                                            RuleDsl.value("1")
+                                    )).toArray(Expression[]::new)
+                            )
+                    )
+                    .action("collectValueAction",
+                            RuleDsl.param("context", RuleDsl.value("${ctx}")),
+                            RuleDsl.param("fact", RuleDsl.value("${simpleStringValueFact}")))
+                    .build();
+        }
+    }
+
+    public static class SimpleFact {
+        private String value;
+
+        public SimpleFact(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SimpleFact that = (SimpleFact) o;
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static class CollectValueAction {
+        public void execute(List<SimpleFact> context, SimpleFact fact) {
+            if (fact == null) {
+                System.out.println("Fact IS NULL!\n");
+            }
+            context.add(fact);
+        }
+    }
+}

--- a/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
+++ b/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright 2018 Sabre GLBL Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.sabre.oss.yare.performance.suits;
 
 import com.sabre.oss.yare.core.RuleSession;

--- a/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
+++ b/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
@@ -85,7 +85,7 @@ public class MultithreadedTest {
     @State(Scope.Thread)
     public static class FactsState {
 
-        @Param({"50","100"})
+        @Param({"50", "100"})
         public int numberOfFacts;
         private List<SimpleFact> facts;
 
@@ -100,7 +100,7 @@ public class MultithreadedTest {
 
     @State(Scope.Thread)
     public static class EngineState {
-        @Param({"50","100"})
+        @Param({"50", "100"})
         public int numberOfRules;
         @Param({"5", "50", "500"})
         public int ruleComplexity;

--- a/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
+++ b/yare-performance/src/test/java/com/sabre/oss/yare/performance/suits/MultithreadedTest.java
@@ -84,7 +84,7 @@ public class MultithreadedTest {
 
     @State(Scope.Thread)
     public static class FactsState {
-        public static int NUMBER_OF_FACTS = 1000;
+        public static final int NUMBER_OF_FACTS = 1000;
         private List<SimpleFact> facts;
 
         @Setup(Level.Invocation)
@@ -98,7 +98,7 @@ public class MultithreadedTest {
 
     @State(Scope.Thread)
     public static class EngineState {
-        public static int NUMBER_OF_RULES = 500;
+        public static final int NUMBER_OF_RULES = 500;
         private RulesEngine engine;
 
         @Setup(Level.Invocation)


### PR DESCRIPTION
Increasing the throughput of getting valueProviders by allowing concurrent read/writes on the map without locking the entire collection.
 
# After:
Warmup Iteration   1: 24720.953 ±(99.9%) 1990.813 ms/op
Warmup Iteration   2: 24258.182 ±(99.9%) 1285.860 ms/op
Iteration   1: 25135.823 ±(99.9%) 1196.562 ms/op
Iteration   2: 23966.300 ±(99.9%) 1276.853 ms/op
Iteration   3: 25538.036 ±(99.9%) 1964.715 ms/op
Iteration   4: 26969.966 ±(99.9%) 2155.508 ms/op
Iteration   5: 26302.678 ±(99.9%) 3366.828 ms/op

Result "com.sabre.oss.yare.performance.suits.MultithreadedTest.benchmark":
  25582.560 ±(99.9%) 4414.541 ms/op [Average]
  (min, avg, max) = (23966.300, 25582.560, 26969.966), stdev = 1146.442
  CI (99.9%): [21168.019, 29997.102] (assumes normal distribution)


# Before:  
Warmup Iteration   1: 30711.778 ±(99.9%) 3640.221 ms/op
Warmup Iteration   2: 34629.744 ±(99.9%) 4227.998 ms/op
Iteration   1: 30236.826 ±(99.9%) 2876.878 ms/op
Iteration   2: 30757.804 ±(99.9%) 3400.727 ms/op
Iteration   3: 30518.556 ±(99.9%) 3088.247 ms/op
Iteration   4: 33057.338 ±(99.9%) 2871.403 ms/op
Iteration   5: 30440.224 ±(99.9%) 3197.480 ms/op

Result "com.sabre.oss.yare.performance.suits.MultithreadedTest.benchmark":
  31002.149 ±(99.9%) 4481.845 ms/op [Average]
  (min, avg, max) = (30236.826, 31002.149, 33057.338), stdev = 1163.921
  CI (99.9%): [26520.305, 35483.994] (assumes normal distribution)

![lock](https://user-images.githubusercontent.com/12997861/63272148-d1f93380-c29b-11e9-81e1-fb146dafab47.PNG)

